### PR TITLE
Fix broken link

### DIFF
--- a/ns/besluit/index.html
+++ b/ns/besluit/index.html
@@ -629,7 +629,7 @@ Modellicentie Gratis Hergebruik - v1.0</a>.</p>
                                     
                                     </p>
                                     <br />
-                                    <p><a href="http://visualdataweb.de/webvowl/#iri=http://data.vlaanderen.be/ns/besluit.ttl">Verken het vocabularium</a></p>
+                                    <p><a href="http://service.tib.eu/webvowl/#iri=http://data.vlaanderen.be/ns/besluit.ttl">Verken het vocabularium</a></p>
                                 </div>
 
                                 


### PR DESCRIPTION
visualdataweb.de no longer resolves.

You may want to use service.tib.eu and replace all occurences, cf. https://github.com/search?q=org%3AInformatievlaanderen%20visualdataweb&type=code